### PR TITLE
feat: add KOL category with detail view and various improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,30 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
+      - name: Sync version from git tag
+        shell: bash
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Syncing version to $VERSION"
+
+          # Update package.json and tauri.conf.json using Node.js (cross-platform)
+          node -e "
+            const fs = require('fs');
+
+            // Update package.json
+            const pkg = JSON.parse(fs.readFileSync('package.json'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+            // Update tauri.conf.json
+            const tauri = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));
+            tauri.version = '$VERSION';
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(tauri, null, 2) + '\n');
+
+            console.log('Version synced to $VERSION');
+          "
+
       - name: Install frontend dependencies
         run: npm ci
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, NavLink, useNavigate } from 'react-router-dom'
-import { Search, Package, RefreshCw, Settings, Heart, Folder, PlusCircle, ExternalLink } from 'lucide-react'
+import { Search, Package, RefreshCw, Settings, Heart, Folder, PlusCircle, ExternalLink, Store } from 'lucide-react'
 import { open } from '@tauri-apps/plugin-shell'
 import { useEffect, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -13,12 +13,14 @@ import SettingsPage from './pages/Settings'
 import Favorites from './pages/Favorites'
 import Collections from './pages/Collections'
 import CreateSkill from './pages/CreateSkill'
+import Marketplace from './pages/Marketplace'
 import Toast from './components/Toast'
 import UserMenu from './components/UserMenu'
 import SearchDialog from './components/SearchDialog'
 
 const navItems = [
   { path: '/', icon: Search, label: 'Discover' },
+  { path: '/marketplace', icon: Store, label: 'Marketplace' },
   { path: '/create', icon: PlusCircle, label: 'Create' },
   { path: '/favorites', icon: Heart, label: 'Favorites', authRequired: true },
   { path: '/collections', icon: Folder, label: 'Collections', authRequired: true },
@@ -28,7 +30,7 @@ const navItems = [
 ]
 
 function App() {
-  const { setTools, toastMessage, setToastMessage, isAuthenticated } = useAppStore()
+  const { setTools, toast, hideToast, toastMessage, setToastMessage, isAuthenticated } = useAppStore()
   const { t } = useTranslation()
   const navigate = useNavigate()
 
@@ -126,6 +128,7 @@ function App() {
       <main className="flex-1 overflow-auto bg-background">
         <Routes>
           <Route path="/" element={<Discover />} />
+          <Route path="/marketplace" element={<Marketplace />} />
           <Route path="/create" element={<CreateSkill />} />
           <Route path="/favorites" element={<Favorites />} />
           <Route path="/collections" element={<Collections />} />
@@ -136,6 +139,9 @@ function App() {
       </main>
 
       {/* Toast */}
+      {toast && (
+        <Toast message={toast.message} type={toast.type} onClose={hideToast} />
+      )}
       {toastMessage && (
         <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
       )}

--- a/src/components/KolDetail.tsx
+++ b/src/components/KolDetail.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from 'react'
+import { X, Users, Star, ExternalLink, Loader2 } from 'lucide-react'
+import { open } from '@tauri-apps/plugin-shell'
+import { getKolDetail, type KolUser, type KolDetailResponse } from '../api/skillhub'
+import { useAppStore } from '../store'
+import SkillCard from './SkillCard'
+import type { SkillHubSkill } from '../types'
+
+interface KolDetailProps {
+  kol: KolUser
+  onClose: () => void
+  onInstallSkill: (skill: SkillHubSkill) => void
+  onViewSkill: (skill: SkillHubSkill) => void
+}
+
+const SKILLHUB_URL = import.meta.env.VITE_SKILLHUB_API_URL || 'https://www.skillhub.club'
+
+export default function KolDetail({ kol, onClose, onInstallSkill, onViewSkill }: KolDetailProps) {
+  const [detail, setDetail] = useState<KolDetailResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { showToast } = useAppStore()
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+
+    getKolDetail(kol.githubUsername)
+      .then(data => {
+        setDetail(data)
+      })
+      .catch(err => {
+        console.error('Failed to load KOL detail:', err)
+        setError('Failed to load KOL details')
+        showToast('Failed to load KOL details', 'error')
+      })
+      .finally(() => setLoading(false))
+  }, [kol.githubUsername, showToast])
+
+  const openProfile = async () => {
+    try {
+      await open(`${SKILLHUB_URL}/u/${kol.githubUsername}`)
+    } catch (error) {
+      console.error('Failed to open browser:', error)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border-2 border-foreground w-full max-w-4xl mx-4 max-h-[90vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b-2 border-border-light">
+          <div className="flex items-center gap-4">
+            {kol.avatarUrl ? (
+              <img
+                src={kol.avatarUrl}
+                alt={kol.displayName}
+                className="w-16 h-16 border-2 border-foreground"
+              />
+            ) : (
+              <div className="w-16 h-16 border-2 border-foreground flex items-center justify-center bg-secondary">
+                <Users size={32} className="text-muted-foreground" />
+              </div>
+            )}
+            <div>
+              <h2 className="text-xl font-bold tracking-tight">{kol.displayName}</h2>
+              <p className="text-sm text-muted-foreground">@{kol.githubUsername}</p>
+              <div className="flex items-center gap-4 mt-1 text-xs text-muted-foreground uppercase tracking-wider">
+                <span className="flex items-center gap-1">
+                  <Users size={12} />
+                  {kol.githubFollowers.toLocaleString()} followers
+                </span>
+                <span className="flex items-center gap-1">
+                  <Star size={12} />
+                  {detail?.user?.stats?.totalStars?.toLocaleString() || kol.skillCount} stars
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={openProfile}
+              className="p-2 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+              title="View on SkillHub"
+            >
+              <ExternalLink size={20} />
+            </button>
+            <button
+              onClick={onClose}
+              className="p-2 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Bio */}
+        {kol.bio && (
+          <div className="px-4 py-3 border-b border-border-light">
+            <p className="text-sm text-muted-foreground">{kol.bio}</p>
+          </div>
+        )}
+
+        {/* Skills */}
+        <div className="flex-1 overflow-y-auto p-4">
+          <h3 className="text-sm font-bold uppercase tracking-wider text-muted-foreground mb-4">
+            Skills by {kol.displayName}
+          </h3>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="animate-spin text-foreground" size={32} />
+            </div>
+          ) : error ? (
+            <div className="text-center py-12 text-muted-foreground">
+              {error}
+            </div>
+          ) : detail?.skills && detail.skills.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {detail.skills.map(skill => (
+                <SkillCard
+                  key={skill.id}
+                  skill={skill}
+                  onInstall={onInstallSkill}
+                  onView={onViewSkill}
+                  installing={false}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12 text-muted-foreground">
+              No skills found
+            </div>
+          )}
+
+          {detail?.pagination?.hasMore && (
+            <div className="mt-6 text-center">
+              <button
+                onClick={openProfile}
+                className="btn btn-secondary"
+              >
+                <ExternalLink size={18} />
+                View all skills on SkillHub
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t-2 border-border-light">
+          <p className="text-xs text-muted-foreground text-center uppercase tracking-wider">
+            {detail?.pagination?.total || kol.skillCount} skills total
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -38,9 +38,9 @@ const TOOL_CONFIG_FOLDERS: Record<string, string> = {
   cursor: '.cursor',
   cline: '.cline',
   gemini: '.gemini',
-  opencode: '.config/opencode',
+  opencode: '.opencode',
   kilocode: '.kilocode',
-  copilot: '.config/github-copilot',
+  copilot: '.copilot',
   windsurf: '.windsurf',
 }
 

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,0 +1,28 @@
+import { Store } from 'lucide-react'
+
+export default function Marketplace() {
+  return (
+    <div className="p-6 flex flex-col items-center justify-center min-h-[calc(100vh-4rem)]">
+      <div className="text-center max-w-md">
+        <div className="w-24 h-24 mx-auto mb-8 border-4 border-foreground flex items-center justify-center">
+          <Store size={48} className="text-foreground" />
+        </div>
+
+        <h1 className="text-4xl font-bold text-foreground mb-4 tracking-tight">
+          MARKETPLACE
+        </h1>
+
+        <p className="text-xl text-muted-foreground mb-8 uppercase tracking-wider">
+          Coming Soon
+        </p>
+
+        <div className="border-2 border-border-light p-6">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            The SkillHub Marketplace will allow you to discover, purchase, and sell premium AI coding skills.
+            Stay tuned for updates!
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,15 +1,23 @@
 import { useState } from 'react'
-import { ExternalLink, Globe } from 'lucide-react'
+import { ExternalLink, Globe, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { setLanguage, getLanguage } from '../i18n'
+import { clearCache } from '../api/skillhub'
+import { useAppStore } from '../store'
 
 export default function Settings() {
   const { t } = useTranslation()
   const [currentLang, setCurrentLang] = useState(getLanguage())
+  const { showToast } = useAppStore()
 
   const handleLanguageChange = (lang: string) => {
     setLanguage(lang)
     setCurrentLang(lang)
+  }
+
+  const handleClearCache = () => {
+    clearCache()
+    showToast('Cache cleared', 'success')
   }
 
   return (
@@ -48,6 +56,28 @@ export default function Settings() {
               }`}
             >
               {t('settings.chinese')}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Cache */}
+      <section className="mb-8">
+        <h2 className="swiss-label mb-4">CACHE</h2>
+        <div className="card p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Trash2 size={20} className="text-muted-foreground" />
+              <div>
+                <p className="text-sm font-semibold text-foreground">Clear API Cache</p>
+                <p className="text-xs text-muted-foreground">Clear cached KOL and catalog data to fetch fresh content</p>
+              </div>
+            </div>
+            <button
+              onClick={handleClearCache}
+              className="btn btn-secondary text-sm"
+            >
+              Clear Cache
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add KOL category to Discover page with clickable user cards
- Add KolDetail modal showing KOL profile and their skills (with install/view actions)
- Add API caching system (5-minute TTL) to reduce server load
- Add cache clear button in Settings page
- Add Marketplace page placeholder
- Fix toast notifications not appearing after skill install
- Fix AI tool paths to only manage skills directories
- Add automatic version sync from git tags in CI/CD

## Test plan
- [ ] Click KOL category, verify KOL cards display
- [ ] Click a KOL card, verify detail modal shows their skills
- [ ] Install a skill from KOL detail, verify toast appears
- [ ] Clear cache from Settings, verify it works
- [ ] Check Marketplace tab shows Coming Soon