### PR TITLE
feat: add import from personal and search deduplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillhub-desktop",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "SkillHub Desktop - Manage AI coding skills across all your tools",
   "type": "module",
   "scripts": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Release script for SkillHub Desktop
+# Usage: ./scripts/release.sh [patch|minor|major] or ./scripts/release.sh <version>
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get current version from package.json
+CURRENT_VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"version": "\([^"]*\)".*/\1/')
+
+echo -e "${YELLOW}Current version: ${CURRENT_VERSION}${NC}"
+
+# Determine new version
+if [ -z "$1" ]; then
+    echo -e "${RED}Usage: ./scripts/release.sh [patch|minor|major|<version>]${NC}"
+    echo "  patch  - bump patch version (0.1.8 -> 0.1.9)"
+    echo "  minor  - bump minor version (0.1.8 -> 0.2.0)"
+    echo "  major  - bump major version (0.1.8 -> 1.0.0)"
+    echo "  <version> - set specific version (e.g., 0.2.0)"
+    exit 1
+fi
+
+# Parse version parts
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$1" in
+    patch)
+        NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+        ;;
+    minor)
+        NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+        ;;
+    major)
+        NEW_VERSION="$((MAJOR + 1)).0.0"
+        ;;
+    *)
+        # Assume it's a specific version
+        NEW_VERSION="$1"
+        ;;
+esac
+
+echo -e "${GREEN}New version: ${NEW_VERSION}${NC}"
+
+# Confirmation
+read -p "Proceed with release v${NEW_VERSION}? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+# Pre-release checklist
+echo ""
+echo -e "${YELLOW}=== Pre-release Checklist ===${NC}"
+echo "Please verify:"
+echo "  [ ] All changes are committed"
+echo "  [ ] Tests pass (if applicable)"
+echo "  [ ] PR is merged to main"
+echo ""
+read -p "All checks passed? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Please complete the checklist first."
+    exit 1
+fi
+
+# Ensure we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo -e "${YELLOW}Switching to main branch...${NC}"
+    git checkout main
+    git pull origin main
+fi
+
+# Update version in package.json
+echo -e "${YELLOW}Updating package.json...${NC}"
+sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" package.json
+
+# Update version in tauri.conf.json
+echo -e "${YELLOW}Updating tauri.conf.json...${NC}"
+sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" src-tauri/tauri.conf.json
+
+# Verify updates
+echo -e "${GREEN}Updated versions:${NC}"
+echo "  package.json: $(grep '"version"' package.json | head -1)"
+echo "  tauri.conf.json: $(grep '"version"' src-tauri/tauri.conf.json)"
+
+# Commit version bump
+echo -e "${YELLOW}Committing version bump...${NC}"
+git add package.json src-tauri/tauri.conf.json
+git commit -m "chore: bump version to ${NEW_VERSION}"
+
+# Create and push tag
+echo -e "${YELLOW}Creating tag v${NEW_VERSION}...${NC}"
+git tag "v${NEW_VERSION}"
+
+# Push
+echo -e "${YELLOW}Pushing to origin...${NC}"
+git push origin main
+git push origin "v${NEW_VERSION}"
+
+echo ""
+echo -e "${GREEN}=== Release v${NEW_VERSION} complete! ===${NC}"
+echo ""
+echo "GitHub Actions will now build and create the release."
+echo "Check: https://github.com/skillhub-club/skillhub-desktop/releases"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -380,6 +380,18 @@ async fn get_tool_directories(tool_id: String) -> Result<tools::ToolDirectories,
     tools::get_tool_directories(&tool_id).await
 }
 
+// Copy a skill from source to destination directory
+#[tauri::command]
+async fn copy_skill(source_path: String, dest_dir: String) -> Result<String, String> {
+    tools::copy_skill(&source_path, &dest_dir).await
+}
+
+// List skills in a directory (for import picker)
+#[tauri::command]
+async fn list_skills_in_dir(dir_path: String) -> Result<Vec<InstalledSkill>, String> {
+    tools::list_skills_in_dir(&dir_path).await
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -407,6 +419,8 @@ pub fn run() {
             get_claude_directories,
             check_path_exists,
             get_tool_directories,
+            copy_skill,
+            list_skills_in_dir,
         ])
         .setup(|app| {
             // Create tray menu

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SkillHub Desktop",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "identifier": "com.skillhub.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/api/skillhub.ts
+++ b/src/api/skillhub.ts
@@ -93,7 +93,18 @@ export async function searchSkills(
   query: string,
   limit?: number
 ): Promise<SkillHubSkill[]> {
-  return invoke('search_skills', { query, limit })
+  const results: SkillHubSkill[] = await invoke('search_skills', { query, limit })
+
+  // Deduplicate by slug, keeping the one with highest github_stars
+  const uniqueBySlug = new Map<string, SkillHubSkill>()
+  for (const skill of results) {
+    const existing = uniqueBySlug.get(skill.slug)
+    if (!existing || (skill.github_stars || 0) > (existing.github_stars || 0)) {
+      uniqueBySlug.set(skill.slug, skill)
+    }
+  }
+
+  return Array.from(uniqueBySlug.values())
 }
 
 // Get skill catalog from SkillHub API

--- a/src/components/ImportSkillsModal.tsx
+++ b/src/components/ImportSkillsModal.tsx
@@ -1,0 +1,224 @@
+import { useState, useEffect } from 'react'
+import { X, Loader2, Check, Download } from 'lucide-react'
+import { invoke } from '@tauri-apps/api/core'
+
+interface InstalledSkill {
+  name: string
+  path: string
+  description?: string
+  author?: string
+  tool_id: string
+}
+
+interface ImportSkillsModalProps {
+  sourcePath: string  // Personal skills path (e.g., ~/.claude/skills)
+  destPath: string    // Project skills path (e.g., /project/.claude/skills)
+  toolName: string
+  onClose: () => void
+  onImported: () => void
+}
+
+export default function ImportSkillsModal({
+  sourcePath,
+  destPath,
+  toolName,
+  onClose,
+  onImported
+}: ImportSkillsModalProps) {
+  const [skills, setSkills] = useState<InstalledSkill[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set())
+  const [importing, setImporting] = useState(false)
+  const [importedCount, setImportedCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load personal skills
+  useEffect(() => {
+    setLoading(true)
+    invoke<InstalledSkill[]>('list_skills_in_dir', { dirPath: sourcePath })
+      .then(data => {
+        setSkills(data)
+        setError(null)
+      })
+      .catch(err => {
+        console.error('Failed to load skills:', err)
+        setError('Failed to load personal skills')
+      })
+      .finally(() => setLoading(false))
+  }, [sourcePath])
+
+  const toggleSkill = (path: string) => {
+    setSelectedSkills(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selectedSkills.size === skills.length) {
+      setSelectedSkills(new Set())
+    } else {
+      setSelectedSkills(new Set(skills.map(s => s.path)))
+    }
+  }
+
+  const handleImport = async () => {
+    if (selectedSkills.size === 0) return
+
+    setImporting(true)
+    setImportedCount(0)
+    setError(null)
+
+    let successCount = 0
+    const errors: string[] = []
+
+    for (const skillPath of selectedSkills) {
+      try {
+        await invoke('copy_skill', { sourcePath: skillPath, destDir: destPath })
+        successCount++
+        setImportedCount(successCount)
+      } catch (err) {
+        const skill = skills.find(s => s.path === skillPath)
+        errors.push(`${skill?.name || skillPath}: ${err}`)
+      }
+    }
+
+    setImporting(false)
+
+    if (successCount > 0) {
+      onImported()
+    }
+
+    if (errors.length > 0) {
+      setError(`Some imports failed:\n${errors.join('\n')}`)
+    } else {
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border-2 border-foreground w-full max-w-lg mx-4 max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b-2 border-border-light">
+          <div>
+            <h2 className="text-lg font-bold tracking-tight">IMPORT FROM PERSONAL</h2>
+            <p className="text-sm text-muted-foreground">{toolName} Skills</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-4">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="animate-spin text-foreground" size={24} />
+            </div>
+          ) : skills.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              <p>No personal skills found</p>
+              <p className="text-sm mt-1">{sourcePath}</p>
+            </div>
+          ) : (
+            <>
+              {/* Select all */}
+              <div className="flex items-center justify-between mb-3 pb-3 border-b border-border-light">
+                <span className="text-sm text-muted-foreground">
+                  {selectedSkills.size} of {skills.length} selected
+                </span>
+                <button
+                  onClick={toggleAll}
+                  className="text-sm font-semibold text-foreground hover:underline"
+                >
+                  {selectedSkills.size === skills.length ? 'Deselect All' : 'Select All'}
+                </button>
+              </div>
+
+              {/* Skills list */}
+              <div className="space-y-2">
+                {skills.map(skill => (
+                  <button
+                    key={skill.path}
+                    onClick={() => toggleSkill(skill.path)}
+                    className={`w-full p-3 text-left border-2 transition-colors ${
+                      selectedSkills.has(skill.path)
+                        ? 'border-foreground bg-secondary'
+                        : 'border-border-light hover:border-foreground'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className={`w-5 h-5 border-2 flex items-center justify-center ${
+                        selectedSkills.has(skill.path)
+                          ? 'border-foreground bg-foreground'
+                          : 'border-muted-foreground'
+                      }`}>
+                        {selectedSkills.has(skill.path) && (
+                          <Check size={14} className="text-background" />
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold truncate">{skill.name}</h4>
+                        {skill.description && (
+                          <p className="text-sm text-muted-foreground truncate">{skill.description}</p>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {error && (
+            <div className="mt-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm whitespace-pre-wrap">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-3 p-4 border-t-2 border-border-light">
+          <button
+            onClick={onClose}
+            className="btn btn-secondary flex-1"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleImport}
+            disabled={importing || selectedSkills.size === 0}
+            className="btn btn-primary flex-1 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {importing ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                Importing... ({importedCount}/{selectedSkills.size})
+              </>
+            ) : (
+              <>
+                <Download size={16} />
+                Import {selectedSkills.size > 0 ? `(${selectedSkills.size})` : ''}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add "Import from Personal" feature in project skill management - allows importing skills from personal collection to project-level
- Add search result deduplication by slug (keeping entry with highest github_stars)
- Bump version to 0.1.8

## Changes
- **Backend (Rust)**: Added `copy_skill` and `list_skills_in_dir` commands for file operations
- **Frontend**: New `ImportSkillsModal` component for selecting skills to import
- **UI**: Import button now shows "Import" text with icon on hover
- **API**: Added deduplication logic to `searchSkills()` function

## Test plan
- [ ] Test importing skills from Personal to a Project
- [ ] Verify search results no longer show duplicates
- [ ] Verify version displays as 0.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)