### PR TITLE
feat: implement user marketplace with cover preview and correct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillhub-desktop",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillhub-desktop",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -26,6 +26,7 @@
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.2",
         "i18next": "^25.7.4",
         "lucide-react": "^0.469.0",
         "react": "^19.0.0",
@@ -3261,6 +3262,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.2",
     "i18next": "^25.7.4",
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -8,6 +8,14 @@ interface SkillCardProps {
   onInstall: (skill: SkillHubSkill) => void
   onView?: (skill: SkillHubSkill) => void
   installing?: boolean
+  showPreviewButton?: boolean
+  customUrl?: string
+  meta?: {
+    coverUrl?: string
+    views?: number
+    downloads?: number
+    ownerName?: string
+  }
 }
 
 function getRatingBadge(rating?: string) {
@@ -31,7 +39,7 @@ function getCategoryColor(category?: string) {
   }
 }
 
-export default function SkillCard({ skill, onInstall, onView, installing }: SkillCardProps) {
+export default function SkillCard({ skill, onInstall, onView, installing, showPreviewButton = false, customUrl, meta }: SkillCardProps) {
   const { i18n } = useTranslation()
   
   // Select description based on current language
@@ -41,9 +49,34 @@ export default function SkillCard({ skill, onInstall, onView, installing }: Skil
 
   return (
     <div
-      className="card p-4 cursor-pointer flex flex-col overflow-hidden"
+      className="card p-0 cursor-pointer flex flex-col overflow-hidden"
       onClick={() => onView?.(skill)}
     >
+      <div className="relative h-32 w-full overflow-hidden border-b border-border-light bg-secondary">
+        {meta?.coverUrl ? (
+          <img
+            src={meta.coverUrl}
+            alt={skill.name}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="h-full w-full bg-gradient-to-br from-foreground/10 via-secondary to-background flex items-center justify-center text-[11px] uppercase tracking-wider text-muted-foreground">
+            No cover
+          </div>
+        )}
+        {showPreviewButton && onView && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onView(skill)
+            }}
+            className="absolute bottom-2 right-2 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider bg-background/90 border border-border-light hover:border-foreground hover:bg-background transition-colors"
+          >
+            Preview
+          </button>
+        )}
+      </div>
+      <div className="p-4 flex flex-col flex-1">
       {/* Header */}
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="min-w-0 flex-1">
@@ -56,7 +89,9 @@ export default function SkillCard({ skill, onInstall, onView, installing }: Skil
               </span>
             )}
           </div>
-          <p className="text-xs text-muted-foreground uppercase tracking-wider truncate">by {skill.author}</p>
+          <p className="text-xs text-muted-foreground uppercase tracking-wider truncate">
+            {meta?.ownerName ? `by ${meta.ownerName}` : `by ${skill.author}`}
+          </p>
         </div>
         {skill.simple_rating && (
           <span className={`px-2 py-0.5 text-xs font-bold uppercase flex-shrink-0 ${getRatingBadge(skill.simple_rating)}`}>
@@ -71,7 +106,7 @@ export default function SkillCard({ skill, onInstall, onView, installing }: Skil
       </p>
 
       {/* Meta info */}
-      <div className="flex items-center gap-2 text-sm mb-3 min-w-0">
+      <div className="flex items-center gap-2 text-sm mb-3 min-w-0 flex-wrap">
         {skill.github_stars !== undefined && skill.github_stars > 0 && (
           <span className="flex items-center gap-1 text-muted-foreground flex-shrink-0">
             <Star size={14} className="text-yellow-500" />
@@ -81,28 +116,54 @@ export default function SkillCard({ skill, onInstall, onView, installing }: Skil
         <span className={`tag text-white truncate max-w-[120px] ${getCategoryColor(skill.category)}`}>
           {skill.category}
         </span>
+        {meta?.views !== undefined && (
+          <span className="flex items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+            <Eye size={12} />
+            {meta.views.toLocaleString()} views
+          </span>
+        )}
+        {meta?.downloads !== undefined && (
+          <span className="flex items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+            <Download size={12} />
+            {meta.downloads.toLocaleString()} installs
+          </span>
+        )}
       </div>
 
       {/* Actions - 使用 mt-auto 推到底部 */}
       <div className="flex items-center justify-between gap-2 mt-auto pt-2 border-t border-border-light">
-        <div className="flex items-center">
+        <div className="flex items-center gap-1">
           {onView && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onView(skill)
-              }}
-              className="p-1.5 text-muted-foreground hover:text-foreground transition-colors"
-              title="View Details"
-            >
-              <Eye size={16} />
-            </button>
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onView(skill)
+                }}
+                className="p-1.5 text-muted-foreground hover:text-foreground transition-colors"
+                title="View Details"
+              >
+                <Eye size={16} />
+              </button>
+              {showPreviewButton && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onView(skill)
+                  }}
+                  className="btn btn-secondary px-3 py-1.5 text-xs uppercase tracking-wider"
+                >
+                  Preview
+                </button>
+              )}
+            </>
           )}
           <button
             onClick={(e) => {
               e.stopPropagation()
               const skillhubUrl = import.meta.env.VITE_SKILLHUB_API_URL || 'https://www.skillhub.club'
-              open(`${skillhubUrl}/skills/${skill.slug}`).catch(console.error)
+              const path = customUrl || `/skills/${skill.slug}`
+              open(`${skillhubUrl}${path.startsWith('/') ? '' : '/'}${path}`).catch(console.error)
             }}
             className="p-1.5 text-muted-foreground hover:text-foreground transition-colors"
             title="View on SkillHub"
@@ -125,6 +186,7 @@ export default function SkillCard({ skill, onInstall, onView, installing }: Skil
           )}
           <span>{installing ? '...' : 'Install'}</span>
         </button>
+      </div>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -292,3 +292,77 @@ h1, h2, h3, h4, h5, h6 {
     transform: scale3d(0, 0, 1);
   }
 }
+
+/* MDEditor Dark Mode Support */
+.dark [data-color-mode="dark"] .w-md-editor {
+  --color-canvas-default: var(--background);
+  --color-canvas-subtle: var(--secondary);
+  --color-fg-default: var(--foreground);
+  --color-fg-muted: var(--muted-foreground);
+  --color-border-default: var(--border-light);
+  --color-border-muted: var(--border-light);
+  background-color: var(--background) !important;
+  color: var(--foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .w-md-editor-toolbar {
+  background-color: var(--secondary) !important;
+  border-color: var(--border-light) !important;
+}
+
+.dark [data-color-mode="dark"] .w-md-editor-toolbar li > button {
+  color: var(--foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .w-md-editor-toolbar li > button:hover {
+  background-color: var(--muted) !important;
+}
+
+.dark [data-color-mode="dark"] .w-md-editor-text-pre,
+.dark [data-color-mode="dark"] .w-md-editor-text-input,
+.dark [data-color-mode="dark"] .w-md-editor-text {
+  color: var(--foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown {
+  background-color: transparent !important;
+  color: var(--foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown pre,
+.dark [data-color-mode="dark"] .wmde-markdown code {
+  background-color: var(--secondary) !important;
+  color: var(--foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown h1,
+.dark [data-color-mode="dark"] .wmde-markdown h2,
+.dark [data-color-mode="dark"] .wmde-markdown h3,
+.dark [data-color-mode="dark"] .wmde-markdown h4,
+.dark [data-color-mode="dark"] .wmde-markdown h5,
+.dark [data-color-mode="dark"] .wmde-markdown h6 {
+  color: var(--foreground) !important;
+  border-color: var(--border-light) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown a {
+  color: #60a5fa !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown blockquote {
+  border-color: var(--border-light) !important;
+  color: var(--muted-foreground) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown table th,
+.dark [data-color-mode="dark"] .wmde-markdown table td {
+  border-color: var(--border-light) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown table tr:nth-child(2n) {
+  background-color: var(--secondary) !important;
+}
+
+.dark [data-color-mode="dark"] .wmde-markdown hr {
+  background-color: var(--border-light) !important;
+}

--- a/src/pages/CreateSkill.tsx
+++ b/src/pages/CreateSkill.tsx
@@ -1,12 +1,893 @@
+import { useState, useRef, useEffect } from 'react'
+import {
+  Sparkles,
+  Upload,
+  UploadCloud,
+  Save,
+  Eye,
+  EyeOff,
+  Globe,
+  Lock,
+  Link2,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  ChevronDown,
+  HardDrive,
+  Cloud,
+  Info,
+  FolderArchive,
+  FilePlus2,
+  FileText,
+  Trash2,
+} from 'lucide-react'
+import MDEditor from '@uiw/react-md-editor'
+import { unzipSync, zipSync, strFromU8, strToU8 } from 'fflate'
+import { useAppStore } from '../store'
+import { detectTools, installSkill, installSkillFiles, getUploadUrl } from '../api/skillhub'
+import {
+  createUserSkill,
+  uploadSkillFiles,
+  publishSkill,
+} from '../api/skillhub'
+import AIGenerateDialog from '../components/AIGenerateDialog'
+import ToolSelector from '../components/ToolSelector'
+import type { SkillVisibility, UserSkillFile } from '../types'
+
+const CATEGORIES = [
+  { id: 'development', label: 'Development' },
+  { id: 'devops', label: 'DevOps' },
+  { id: 'testing', label: 'Testing' },
+  { id: 'documentation', label: 'Documentation' },
+  { id: 'ai-ml', label: 'AI/ML' },
+  { id: 'frontend', label: 'Frontend' },
+  { id: 'backend', label: 'Backend' },
+  { id: 'security', label: 'Security' },
+  { id: 'other', label: 'Other' },
+]
+
+const VISIBILITY_OPTIONS: { id: SkillVisibility; label: string; icon: React.ReactNode; desc: string }[] = [
+  { id: 'public', label: 'Public', icon: <Globe size={16} />, desc: 'Anyone can discover and use' },
+  { id: 'unlisted', label: 'Unlisted', icon: <Link2 size={16} />, desc: 'Only accessible via link' },
+  { id: 'private', label: 'Private', icon: <Lock size={16} />, desc: 'Only you can access' },
+]
+
+type SaveTarget = 'local' | 'cloud'
+
+const SKILL_TEMPLATE = `# Skill Name
+
+Brief description of what this skill does.
+
+## When to Use
+
+- Use case 1
+- Use case 2
+
+## Instructions
+
+Detailed instructions for the AI assistant...
+
+## Examples
+
+\`\`\`
+Example usage or code
+\`\`\`
+`
+
+const MAX_PACKAGE_BYTES = 30 * 1024 * 1024
+
+type SkillFile = {
+  path: string
+  data: Uint8Array
+  text?: string
+  isBinary: boolean
+  size: number
+}
+
+function slugify(name: string) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-]+|[-]+$/g, '') || 'skill'
+}
+
+function createTextFile(path: string, content: string): SkillFile {
+  const data = strToU8(content)
+  return { path, data, text: content, isBinary: false, size: data.length }
+}
+
+function looksBinary(data: Uint8Array): boolean {
+  const sample = Math.min(data.length, 512)
+  let controlBytes = 0
+  for (let i = 0; i < sample; i++) {
+    const b = data[i]
+    if (b === 9 || b === 10 || b === 13) continue
+    if (b < 32 || b === 127) controlBytes++
+  }
+  return controlBytes / sample > 0.3
+}
+
+function getContentType(path: string): string {
+  const lower = path.toLowerCase()
+  if (lower.endsWith('.md')) return 'text/markdown'
+  if (lower.endsWith('.json')) return 'application/json'
+  if (lower.endsWith('.txt')) return 'text/plain'
+  if (lower.endsWith('.ts')) return 'text/plain'
+  if (lower.endsWith('.js')) return 'application/javascript'
+  if (lower.endsWith('.py')) return 'text/x-python'
+  if (lower.endsWith('.sh')) return 'text/x-shellscript'
+  return 'application/octet-stream'
+}
+
+function classifyKind(path: string): UserSkillFile['kind'] {
+  const lower = path.toLowerCase()
+  if (lower === 'skill.md') return 'skill_md'
+  if (lower.includes('manifest')) return 'manifest'
+  if (lower.startsWith('assets/')) return 'asset'
+  return 'other'
+}
+
+function hasSkillMd(files: SkillFile[]) {
+  return files.some(f => f.path.toLowerCase() === 'skill.md')
+}
+
+function totalSize(files: SkillFile[]) {
+  return files.reduce((sum, f) => sum + f.size, 0)
+}
+
 export default function CreateSkill() {
+  const { isAuthenticated, accessToken, tools, setTools, selectedToolIds, showToast, theme } = useAppStore()
+
+  // Form state
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [descriptionZh, setDescriptionZh] = useState('')
+  const [category, setCategory] = useState('development')
+  const [tags, setTags] = useState('')
+  const [visibility, setVisibility] = useState<SkillVisibility>('private')
+
+  // UI state
+  const [saveTarget, setSaveTarget] = useState<SaveTarget>('local')
+  const [showAIDialog, setShowAIDialog] = useState(false)
+  const [showPreview, setShowPreview] = useState(false)
+  const [showCategoryDropdown, setShowCategoryDropdown] = useState(false)
+  const [showVisibilityDropdown, setShowVisibilityDropdown] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [files, setFiles] = useState<SkillFile[]>([createTextFile('SKILL.md', SKILL_TEMPLATE)])
+  const [activeFile, setActiveFile] = useState('SKILL.md')
+  const [binaryNotice, setBinaryNotice] = useState<string | null>(null)
+  const importInputRef = useRef<HTMLInputElement>(null)
+
+  const categoryRef = useRef<HTMLDivElement>(null)
+  const visibilityRef = useRef<HTMLDivElement>(null)
+
+  // Load tools on mount
+  useEffect(() => {
+    detectTools().then(setTools).catch(console.error)
+  }, [setTools])
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (categoryRef.current && !categoryRef.current.contains(e.target as Node)) {
+        setShowCategoryDropdown(false)
+      }
+      if (visibilityRef.current && !visibilityRef.current.contains(e.target as Node)) {
+        setShowVisibilityDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  // Reset success state after delay
+  useEffect(() => {
+    if (saveSuccess) {
+      const timer = setTimeout(() => setSaveSuccess(false), 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [saveSuccess])
+
+  const handleAIApply = (generatedContent: string, _generationId: string) => {
+    setFiles(prev => {
+      const updated = prev.map(f => f.path.toLowerCase() === 'skill.md'
+        ? createTextFile(f.path, generatedContent)
+        : f
+      )
+      if (!updated.some(f => f.path.toLowerCase() === 'skill.md')) {
+        updated.unshift(createTextFile('SKILL.md', generatedContent))
+      }
+      return updated
+    })
+    setActiveFile('SKILL.md')
+    const nameMatch = generatedContent.match(/^#\s+(.+)$/m)
+    if (nameMatch && !name) setName(nameMatch[1].trim())
+  }
+
+  const validateForm = (): string | null => {
+    if (!name.trim()) return 'Please enter a skill name'
+    if (!hasSkillMd(files)) return 'SKILL.md is required'
+    if (totalSize(files) > MAX_PACKAGE_BYTES) return 'Package exceeds 30MB limit'
+    if (saveTarget === 'local' && selectedToolIds.length === 0) {
+      return 'Please select at least one tool to install to'
+    }
+    if (saveTarget === 'cloud' && !isAuthenticated) {
+      return 'Please login to upload to cloud'
+    }
+    return null
+  }
+
+  const handleSaveLocal = async () => {
+    if (selectedToolIds.length === 0) {
+      showToast('Please select at least one tool', 'warning')
+      return
+    }
+
+    const textFiles = files.filter(f => !f.isBinary)
+    if (textFiles.length === 0) {
+      showToast('Cannot install: only binary files found. Export Claude zip instead.', 'warning')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const skillName = slugify(name)
+      const skillMd = textFiles.find(f => f.path.toLowerCase() === 'skill.md')
+
+      if (textFiles.length === 1 && skillMd) {
+        await installSkill(skillMd.text || strFromU8(skillMd.data), skillName, selectedToolIds)
+      } else {
+        const installable = textFiles.map(f => ({
+          path: f.path,
+          content: f.text || strFromU8(f.data),
+        }))
+        await installSkillFiles(installable, skillName, selectedToolIds)
+      }
+
+      if (files.some(f => f.isBinary)) {
+        showToast('Installed text files. Binary assets available in Claude zip export.', 'warning')
+      } else {
+        showToast(`Skill installed to ${selectedToolIds.length} tool(s)`, 'success')
+      }
+      setSaveSuccess(true)
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to install skill', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSaveCloud = async () => {
+    if (!isAuthenticated || !accessToken) {
+      showToast('Please login to upload to cloud', 'warning')
+      return
+    }
+
+    setSaving(true)
+    try {
+      // Step 1: Create skill
+      const skill = await createUserSkill(accessToken, {
+        name: name.trim(),
+        description: description.trim() || name.trim(),
+        description_zh: descriptionZh.trim() || undefined,
+        category,
+        tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+        visibility,
+      })
+
+      const uploadable: UserSkillFile[] = []
+
+      // Upload binary/large files via presigned URL, text inline
+      for (const file of files) {
+        const kind = classifyKind(file.path)
+        const contentType = getContentType(file.path)
+
+        if (!file.isBinary && file.size < 2 * 1024 * 1024) {
+          uploadable.push({
+            filepath: file.path,
+            content: file.text || strFromU8(file.data),
+            kind,
+            contentType,
+            size: file.size,
+          })
+          continue
+        }
+
+        const { uploadUrl, storagePath } = await getUploadUrl(accessToken, skill.id, {
+          filepath: file.path,
+          contentType,
+          size: file.size,
+          kind,
+        })
+
+        const uploadBody = new Uint8Array(file.data)
+
+        await fetch(uploadUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': contentType },
+          body: new Blob([uploadBody], { type: contentType }),
+        })
+
+        uploadable.push({
+          filepath: file.path,
+          storagePath,
+          kind,
+          contentType,
+          size: file.size,
+        })
+      }
+
+      const { version } = await uploadSkillFiles(accessToken, skill.id, {
+        files: uploadable,
+        changeSummary: 'Initial upload',
+      })
+
+      // Step 3: Optionally publish if public/unlisted
+      if (visibility !== 'private') {
+        await publishSkill(accessToken, skill.id, {
+          version,
+          changeSummary: 'Initial release',
+        })
+      }
+
+      showToast(
+        visibility === 'private'
+          ? 'Skill saved as draft'
+          : `Skill published as ${visibility}`,
+        'success'
+      )
+      setSaveSuccess(true)
+
+      // Reset form
+      setName('')
+      setDescription('')
+      setDescriptionZh('')
+      setTags('')
+      setFiles([createTextFile('SKILL.md', SKILL_TEMPLATE)])
+      setActiveFile('SKILL.md')
+      setBinaryNotice(null)
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to upload skill', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSave = () => {
+    const error = validateForm()
+    if (error) {
+      showToast(error, 'warning')
+      return
+    }
+
+    if (saveTarget === 'local') {
+      handleSaveLocal()
+    } else {
+      handleSaveCloud()
+    }
+  }
+
+  const installedTools = tools.filter(t => t.installed)
+  const selectedCategory = CATEGORIES.find(c => c.id === category)
+  const selectedVisibility = VISIBILITY_OPTIONS.find(v => v.id === visibility)
+  const activeFileData = files.find(f => f.path === activeFile)
+
+  const handleFileContentChange = (value: string | undefined) => {
+    if (!activeFileData) return
+    const text = value ?? ''
+    const updated = files.map(f => {
+      if (f.path !== activeFileData.path) return f
+      return createTextFile(f.path, text)
+    })
+    setFiles(updated)
+  }
+
+  const handleAddFile = () => {
+    const newPath = prompt('Enter relative path (e.g., README.md or assets/example.txt)')
+    if (!newPath) return
+    const cleanPath = newPath.trim().replace(/^\/+/, '')
+    if (!cleanPath || cleanPath.includes('..')) {
+      showToast('Invalid path', 'warning')
+      return
+    }
+    if (files.some(f => f.path.toLowerCase() === cleanPath.toLowerCase())) {
+      showToast('File already exists', 'warning')
+      return
+    }
+    const updated = [...files, createTextFile(cleanPath, '')]
+    setFiles(updated)
+    setActiveFile(cleanPath)
+  }
+
+  const handleRemoveFile = (path: string) => {
+    if (path.toLowerCase() === 'skill.md') {
+      showToast('SKILL.md is required', 'warning')
+      return
+    }
+    setFiles(prev => prev.filter(f => f.path !== path))
+    if (activeFile === path) {
+      setActiveFile('SKILL.md')
+    }
+  }
+
+  const handleImportZip = async (file: File) => {
+    if (file.size > MAX_PACKAGE_BYTES) {
+      showToast('Zip exceeds 30MB limit', 'warning')
+      return
+    }
+    try {
+      const data = new Uint8Array(await file.arrayBuffer())
+      const entries = unzipSync(data)
+      const entryNames = Object.keys(entries).filter(name => !name.startsWith('__MACOSX/'))
+      if (entryNames.length === 0) {
+        showToast('Zip is empty', 'warning')
+        return
+      }
+
+      // Require a root folder
+      const first = entryNames[0]
+      const root = first.includes('/') ? first.split('/')[0] : null
+      if (!root) {
+        showToast('Zip must contain a top-level folder with SKILL.md', 'warning')
+        return
+      }
+
+      const imported: SkillFile[] = []
+      let binaryCount = 0
+
+      for (const fullPath of entryNames) {
+        if (!fullPath.startsWith(root + '/')) {
+          showToast('Zip must have a single top-level folder', 'warning')
+          return
+        }
+        const rel = fullPath.slice(root.length + 1)
+        if (!rel || rel.endsWith('/')) continue
+        if (rel.includes('..')) {
+          showToast('Zip contains invalid paths', 'warning')
+          return
+        }
+        const fileData = entries[fullPath]
+        const binary = looksBinary(fileData)
+        const text = binary ? undefined : strFromU8(fileData)
+        if (binary) binaryCount++
+        imported.push({
+          path: rel,
+          data: fileData,
+          text,
+          isBinary: binary,
+          size: fileData.length,
+        })
+      }
+
+      if (!hasSkillMd(imported)) {
+        showToast('SKILL.md missing in zip', 'warning')
+        return
+      }
+
+      setFiles(imported)
+      setActiveFile('SKILL.md')
+      setBinaryNotice(binaryCount > 0 ? `Imported ${binaryCount} binary file(s). They can be exported as Claude zip but not edited.` : null)
+      showToast('Imported Claude zip package', 'success')
+    } catch (error) {
+      console.error(error)
+      showToast('Failed to import zip', 'error')
+    }
+  }
+
+  const handleExportZip = () => {
+    if (!hasSkillMd(files)) {
+      showToast('SKILL.md is required before export', 'warning')
+      return
+    }
+    if (totalSize(files) > MAX_PACKAGE_BYTES) {
+      showToast('Package exceeds 30MB limit', 'warning')
+      return
+    }
+    const folderName = slugify(name || 'my-skill')
+    const zipped = zipSync(
+      files.reduce<Record<string, Uint8Array>>((acc, file) => {
+        acc[`${folderName}/${file.path}`] = file.data
+        return acc
+      }, {}),
+      { level: 6 }
+    )
+    const zippedArray: Uint8Array = zipped instanceof Uint8Array ? new Uint8Array(zipped) : new Uint8Array(zipped)
+    const zippedBuffer = new ArrayBuffer(zippedArray.byteLength)
+    new Uint8Array(zippedBuffer).set(zippedArray)
+    const blob = new Blob([zippedBuffer], { type: 'application/zip' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${folderName}.zip`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const onZipInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleImportZip(file)
+    e.target.value = ''
+  }
+
   return (
-    <div className="p-8">
-      <div className="max-w-2xl">
-        <h1 className="text-2xl font-bold text-foreground">Create Skill</h1>
-        <p className="text-sm text-muted-foreground mt-2">
-          This page is under construction.
-        </p>
+    <div className="h-full flex flex-col bg-background">
+      {/* Header */}
+      <div className="flex-shrink-0 px-6 py-4 border-b border-border">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-foreground">Create Skill</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Write a new skill and save locally or upload to SkillHub Cloud
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".zip"
+              className="hidden"
+              onChange={onZipInputChange}
+            />
+            <button
+              onClick={() => importInputRef.current?.click()}
+              className="flex items-center gap-2 px-3 py-2 border rounded-lg text-foreground hover:border-foreground"
+            >
+              <FolderArchive size={16} />
+              Import Zip
+            </button>
+            <button
+              onClick={handleExportZip}
+              className="flex items-center gap-2 px-3 py-2 border rounded-lg text-foreground hover:border-foreground"
+            >
+              <UploadCloud size={16} />
+              Export Claude Zip
+            </button>
+            <button
+              onClick={() => setShowAIDialog(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+            >
+              <Sparkles size={16} />
+              AI Generate
+            </button>
+            <button
+              onClick={() => setShowPreview(!showPreview)}
+              className={`flex items-center gap-2 px-4 py-2 border rounded-lg transition-colors ${
+                showPreview
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border hover:border-foreground text-foreground'
+              }`}
+            >
+              {showPreview ? <EyeOff size={16} /> : <Eye size={16} />}
+              {showPreview ? 'Edit' : 'Preview'}
+            </button>
+          </div>
+        </div>
       </div>
+
+      {/* Main Content */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Editor Area */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Name Input */}
+          <div className="flex-shrink-0 px-6 py-3 border-b border-border">
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Skill name..."
+              className="w-full text-lg font-semibold bg-transparent border-none outline-none text-foreground placeholder:text-muted-foreground"
+            />
+          </div>
+
+          {/* Files + Editor */}
+          <div className="flex-1 flex overflow-hidden" data-color-mode={theme}>
+            <div className="w-64 border-r border-border flex-shrink-0 flex flex-col">
+              <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+                <span className="text-sm font-medium text-foreground">Files</span>
+                <button
+                  onClick={handleAddFile}
+                  className="flex items-center gap-1 text-xs px-2 py-1 border rounded-md border-border hover:border-foreground"
+                >
+                  <FilePlus2 size={14} />
+                  Add
+                </button>
+              </div>
+              <div className="flex-1 overflow-auto">
+                {files.map(file => (
+                  <div
+                    key={file.path}
+                    className={`flex items-center justify-between px-4 py-2 text-sm cursor-pointer border-b border-border/50 ${
+                      activeFile === file.path ? 'bg-secondary' : 'hover:bg-muted/50'
+                    }`}
+                    onClick={() => setActiveFile(file.path)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <FileText size={14} className={file.path.toLowerCase() === 'skill.md' ? 'text-foreground' : 'text-muted-foreground'} />
+                      <span className="truncate">{file.path}</span>
+                    </div>
+                    {file.path.toLowerCase() !== 'skill.md' && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleRemoveFile(file.path)
+                        }}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label="Remove file"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className="px-4 py-2 text-xs text-muted-foreground border-t border-border">
+                Package size: {(totalSize(files) / (1024 * 1024)).toFixed(1)} MB / 30 MB
+                {binaryNotice && (
+                  <div className="mt-2 text-[11px] text-amber-500">
+                    {binaryNotice}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-auto">
+              {showPreview ? (
+                <div className="p-6 prose dark:prose-invert max-w-none">
+                  <MDEditor.Markdown
+                    source={activeFileData?.isBinary ? '*Binary file preview not supported*' : (activeFileData?.text ?? '')}
+                    style={{ background: 'transparent' }}
+                  />
+                </div>
+              ) : activeFileData?.isBinary ? (
+                <div className="p-6 text-sm text-muted-foreground">
+                  Binary file editing is not supported. Export Claude zip to keep this file.
+                </div>
+              ) : (
+                <MDEditor
+                  value={activeFileData?.text ?? ''}
+                  onChange={handleFileContentChange}
+                  preview="edit"
+                  hideToolbar={false}
+                  height="100%"
+                  className="!bg-transparent"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Right Sidebar */}
+        <div className="w-80 flex-shrink-0 border-l border-border overflow-y-auto">
+          <div className="p-4 space-y-6">
+            {/* Save Target Toggle */}
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Save to
+              </label>
+              <div className="flex rounded-lg border border-border overflow-hidden">
+                <button
+                  onClick={() => setSaveTarget('local')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors ${
+                    saveTarget === 'local'
+                      ? 'bg-foreground text-background'
+                      : 'bg-background text-foreground hover:bg-secondary'
+                  }`}
+                >
+                  <HardDrive size={16} />
+                  Local
+                </button>
+                <button
+                  onClick={() => setSaveTarget('cloud')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors ${
+                    saveTarget === 'cloud'
+                      ? 'bg-foreground text-background'
+                      : 'bg-background text-foreground hover:bg-secondary'
+                  }`}
+                >
+                  <Cloud size={16} />
+                  Cloud
+                </button>
+              </div>
+            </div>
+
+            {/* Local Save Options */}
+            {saveTarget === 'local' && (
+              <div className="space-y-4">
+                <div className="flex items-start gap-2 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+                  <Info size={16} className="text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
+                  <p className="text-xs text-blue-700 dark:text-blue-300">
+                    Skill will be installed directly to selected tools on your machine.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">
+                    Install to
+                  </label>
+                  {installedTools.length > 0 ? (
+                    <ToolSelector compact />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No AI coding tools detected
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Cloud Save Options */}
+            {saveTarget === 'cloud' && (
+              <div className="space-y-4">
+                {!isAuthenticated && (
+                  <div className="flex items-start gap-2 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+                    <AlertCircle size={16} className="text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+                    <p className="text-xs text-yellow-700 dark:text-yellow-300">
+                      Please login to upload skills to SkillHub Cloud.
+                    </p>
+                  </div>
+                )}
+
+                {/* Description */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Description
+                  </label>
+                  <textarea
+                    value={description}
+                    onChange={e => setDescription(e.target.value)}
+                    placeholder="Brief description of your skill..."
+                    className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  />
+                </div>
+
+                {/* Description (Chinese) */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Description (Chinese)
+                    <span className="text-muted-foreground font-normal ml-1">optional</span>
+                  </label>
+                  <textarea
+                    value={descriptionZh}
+                    onChange={e => setDescriptionZh(e.target.value)}
+                    placeholder="中文描述..."
+                    className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground resize-none h-16 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  />
+                </div>
+
+                {/* Category */}
+                <div ref={categoryRef} className="relative">
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Category
+                  </label>
+                  <button
+                    onClick={() => setShowCategoryDropdown(!showCategoryDropdown)}
+                    className="w-full flex items-center justify-between px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground hover:border-foreground transition-colors"
+                  >
+                    <span>{selectedCategory?.label}</span>
+                    <ChevronDown size={16} className={`transition-transform ${showCategoryDropdown ? 'rotate-180' : ''}`} />
+                  </button>
+                  {showCategoryDropdown && (
+                    <div className="absolute z-10 mt-1 w-full bg-background border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                      {CATEGORIES.map(cat => (
+                        <button
+                          key={cat.id}
+                          onClick={() => {
+                            setCategory(cat.id)
+                            setShowCategoryDropdown(false)
+                          }}
+                          className={`w-full px-3 py-2 text-left text-sm text-foreground hover:bg-secondary transition-colors ${
+                            category === cat.id ? 'bg-secondary font-medium' : ''
+                          }`}
+                        >
+                          {cat.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Tags */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Tags
+                    <span className="text-muted-foreground font-normal ml-1">comma separated</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={tags}
+                    onChange={e => setTags(e.target.value)}
+                    placeholder="react, typescript, testing"
+                    className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  />
+                </div>
+
+                {/* Visibility */}
+                <div ref={visibilityRef} className="relative">
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Visibility
+                  </label>
+                  <button
+                    onClick={() => setShowVisibilityDropdown(!showVisibilityDropdown)}
+                    className="w-full flex items-center justify-between px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground hover:border-foreground transition-colors"
+                  >
+                    <span className="flex items-center gap-2">
+                      {selectedVisibility?.icon}
+                      {selectedVisibility?.label}
+                    </span>
+                    <ChevronDown size={16} className={`transition-transform ${showVisibilityDropdown ? 'rotate-180' : ''}`} />
+                  </button>
+                  {showVisibilityDropdown && (
+                    <div className="absolute z-10 mt-1 w-full bg-background border border-border rounded-lg shadow-lg">
+                      {VISIBILITY_OPTIONS.map(opt => (
+                        <button
+                          key={opt.id}
+                          onClick={() => {
+                            setVisibility(opt.id)
+                            setShowVisibilityDropdown(false)
+                          }}
+                          className={`w-full px-3 py-2.5 text-left text-foreground hover:bg-secondary transition-colors ${
+                            visibility === opt.id ? 'bg-secondary' : ''
+                          }`}
+                        >
+                          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                            {opt.icon}
+                            {opt.label}
+                          </div>
+                          <p className="text-xs text-muted-foreground mt-0.5 ml-6">
+                            {opt.desc}
+                          </p>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Save Button */}
+            <button
+              onClick={handleSave}
+              disabled={saving || (saveTarget === 'cloud' && !isAuthenticated)}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
+                saveSuccess
+                  ? 'bg-green-600 text-white'
+                  : saving
+                  ? 'bg-muted text-muted-foreground cursor-not-allowed'
+                  : 'bg-foreground text-background hover:opacity-90'
+              }`}
+            >
+              {saving ? (
+                <>
+                  <Loader2 size={18} className="animate-spin" />
+                  {saveTarget === 'local' ? 'Installing...' : 'Uploading...'}
+                </>
+              ) : saveSuccess ? (
+                <>
+                  <CheckCircle2 size={18} />
+                  {saveTarget === 'local' ? 'Installed!' : 'Uploaded!'}
+                </>
+              ) : (
+                <>
+                  {saveTarget === 'local' ? <Save size={18} /> : <Upload size={18} />}
+                  {saveTarget === 'local' ? 'Install Locally' : 'Upload to Cloud'}
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* AI Generate Dialog */}
+      <AIGenerateDialog
+        open={showAIDialog}
+        onClose={() => setShowAIDialog(false)}
+        onApply={handleAIApply}
+        category={category}
+      />
     </div>
   )
 }

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,28 +1,662 @@
-import { Store } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Store,
+  Search,
+  Tag,
+  Filter,
+  ArrowUpDown,
+  Image,
+  Loader2,
+  X,
+  Users,
+  Clock,
+  RefreshCw,
+} from 'lucide-react'
+import MDEditor from '@uiw/react-md-editor'
+import { open } from '@tauri-apps/plugin-shell'
+import { useAppStore } from '../store'
+import ToolSelector from '../components/ToolSelector'
+import SkillCard from '../components/SkillCard'
+import {
+  detectTools,
+  getSkillFilesForVersion,
+  installSkill,
+  listMarketplaceSkills,
+} from '../api/skillhub'
+import { exchangeCodeForTokens, SKILLHUB_URL } from '../api/auth'
+import type { MarketplaceSkill, MarketplaceSortOption, SkillHubSkill } from '../types'
+
+const PAGE_SIZE = 12
+
+const CATEGORY_OPTIONS = [
+  { id: 'all', label: 'All' },
+  { id: 'development', label: 'Development' },
+  { id: 'devops', label: 'DevOps' },
+  { id: 'testing', label: 'Testing' },
+  { id: 'documentation', label: 'Documentation' },
+  { id: 'ai-ml', label: 'AI/ML' },
+  { id: 'frontend', label: 'Frontend' },
+  { id: 'backend', label: 'Backend' },
+  { id: 'security', label: 'Security' },
+  { id: 'other', label: 'Other' },
+]
+
+const SORT_OPTIONS: { id: MarketplaceSortOption; label: string }[] = [
+  { id: 'published_at_desc', label: 'Newest' },
+  { id: 'updated_at_desc', label: 'Recently Updated' },
+  { id: 'views_desc', label: 'Most Viewed' },
+  { id: 'downloads_desc', label: 'Most Downloaded' },
+  { id: 'name_asc', label: 'Name A-Z' },
+]
+
+type SkillCardAdapted = SkillHubSkill & {
+  skill_path?: string | null
+}
+
+function toSkillCardSkill(skill: MarketplaceSkill): SkillCardAdapted {
+  return {
+    id: skill.id,
+    name: skill.name,
+    slug: skill.slug,
+    description: skill.description,
+    description_zh: skill.description_zh,
+    author: skill.ownerName || 'User',
+    category: skill.category,
+    tags: skill.tags,
+    repo_url: '',
+    skill_md_raw: '',
+    skill_path: null,
+  }
+}
 
 export default function Marketplace() {
-  return (
-    <div className="p-6 flex flex-col items-center justify-center min-h-[calc(100vh-4rem)]">
-      <div className="text-center max-w-md">
-        <div className="w-24 h-24 mx-auto mb-8 border-4 border-foreground flex items-center justify-center">
-          <Store size={48} className="text-foreground" />
+  const {
+    isAuthenticated,
+    accessToken,
+    showToast,
+    theme,
+    selectedToolIds,
+    installTarget,
+    projectPath,
+    setTools,
+    login: loginUser,
+    setFavorites,
+    setCollections,
+  } = useAppStore()
+
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [tag, setTag] = useState('')
+  const [debouncedTag, setDebouncedTag] = useState('')
+  const [category, setCategory] = useState('all')
+  const [sort, setSort] = useState<MarketplaceSortOption>('published_at_desc')
+  const [hasCoverOnly, setHasCoverOnly] = useState(false)
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(PAGE_SIZE)
+  const [total, setTotal] = useState(0)
+  const [skills, setSkills] = useState<MarketplaceSkill[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const [viewingSkill, setViewingSkill] = useState<MarketplaceSkill | null>(null)
+  const [skillContent, setSkillContent] = useState('')
+  const [loadingSkillContent, setLoadingSkillContent] = useState(false)
+  const [installing, setInstalling] = useState(false)
+
+  const [showLoginModal, setShowLoginModal] = useState(false)
+  const [loginCode, setLoginCode] = useState('')
+  const [loggingIn, setLoggingIn] = useState(false)
+
+  // Load installed tools for installation flow
+  useEffect(() => {
+    detectTools().then(setTools).catch(console.error)
+  }, [setTools])
+
+  // Debounce text inputs
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search.trim()), 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedTag(tag.trim()), 300)
+    return () => clearTimeout(timer)
+  }, [tag])
+
+  // Reset to first page when filters change
+  useEffect(() => {
+    setPage(1)
+  }, [debouncedSearch, debouncedTag, category, hasCoverOnly, sort])
+
+  // Fetch marketplace skills
+  useEffect(() => {
+    if (!isAuthenticated || !accessToken) {
+      setSkills([])
+      setTotal(0)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    listMarketplaceSkills(accessToken, {
+      page,
+      pageSize,
+      q: debouncedSearch || undefined,
+      category: category === 'all' ? undefined : category,
+      tag: debouncedTag || undefined,
+      hasCover: hasCoverOnly ? true : undefined,
+      sort,
+    })
+      .then((data) => {
+        setSkills(data.skills || [])
+        setPage(data.page || 1)
+        setPageSize(data.page_size || PAGE_SIZE)
+        setTotal(data.total || 0)
+      })
+      .catch((err) => {
+        console.error('Failed to load marketplace:', err)
+        setSkills([])
+        setError(err instanceof Error ? err.message : 'Failed to load marketplace')
+        showToast('Failed to load marketplace', 'error')
+      })
+      .finally(() => setLoading(false))
+  }, [
+    accessToken,
+    category,
+    debouncedSearch,
+    debouncedTag,
+    hasCoverOnly,
+    isAuthenticated,
+    page,
+    pageSize,
+    refreshKey,
+    showToast,
+    sort,
+  ])
+
+  const totalPages = useMemo(() => {
+    if (!pageSize) return 1
+    return Math.max(1, Math.ceil(total / pageSize))
+  }, [pageSize, total])
+
+  const handleViewSkill = async (skill: MarketplaceSkill) => {
+    if (!accessToken) {
+      showToast('Please sign in to view this skill', 'warning')
+      return
+    }
+
+    setViewingSkill(skill)
+    setSkillContent('')
+    setLoadingSkillContent(true)
+
+    try {
+      const files = await getSkillFilesForVersion(accessToken, skill.id, skill.currentVersion)
+      const skillFile = files.find((f) => f.filepath.toLowerCase() === 'skill.md')
+
+      if (skillFile?.content) {
+        setSkillContent(skillFile.content)
+      } else {
+        setSkillContent('')
+      }
+    } catch (err) {
+      console.error('Failed to load skill files:', err)
+      showToast('Failed to load skill files', 'error')
+    } finally {
+      setLoadingSkillContent(false)
+    }
+  }
+
+  const handleInstall = async () => {
+    if (!viewingSkill) return
+    if (!skillContent) {
+      showToast('Skill content not loaded yet', 'warning')
+      return
+    }
+    if (selectedToolIds.length === 0) {
+      showToast('Please select at least one tool', 'warning')
+      return
+    }
+
+    const safeName =
+      viewingSkill.slug?.trim() ||
+      viewingSkill.name
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .trim() ||
+      'skill'
+
+    setInstalling(true)
+    try {
+      if (installTarget === 'project' && projectPath) {
+        const { invoke } = await import('@tauri-apps/api/core')
+        for (const toolId of selectedToolIds) {
+          await invoke('install_skill_to_project', {
+            skill_content: skillContent,
+            skill_name: safeName,
+            project_path: projectPath,
+            tool_id: toolId,
+          })
+        }
+        showToast(`Installed "${viewingSkill.name}" to project`, 'success')
+      } else {
+        await installSkill(skillContent, safeName, selectedToolIds)
+        showToast(`Installed "${viewingSkill.name}" to ${selectedToolIds.length} tool(s)`, 'success')
+      }
+
+      // Refresh tool state to update counts
+      const newTools = await detectTools()
+      setTools(newTools)
+    } catch (err) {
+      console.error('Installation failed:', err)
+      showToast('Installation failed', 'error')
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  const startLogin = async () => {
+    try {
+      await open(`${SKILLHUB_URL}/web/auth/signin?callback=desktop`)
+      setShowLoginModal(true)
+    } catch (error) {
+      console.error('Failed to open browser:', error)
+      showToast('Failed to open browser for login', 'error')
+    }
+  }
+
+  const handleLoginSubmit = async () => {
+    if (!loginCode.trim()) return
+    setLoggingIn(true)
+    try {
+      const tokens = await exchangeCodeForTokens(loginCode.trim())
+      const expiresAt = Date.now() + tokens.expiresIn * 1000
+
+      const userResponse = await fetch(`${SKILLHUB_URL}/api/v1/oauth/userinfo`, {
+        headers: { Authorization: `Bearer ${tokens.accessToken}` },
+      })
+
+      if (!userResponse.ok) {
+        throw new Error('Failed to get user info')
+      }
+
+      const userData = await userResponse.json()
+
+      loginUser(userData, {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt,
+      })
+
+      const [favoritesRes, collectionsRes] = await Promise.all([
+        fetch(`${SKILLHUB_URL}/api/v1/oauth/favorites`, {
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+        }),
+        fetch(`${SKILLHUB_URL}/api/v1/oauth/collections`, {
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+        }),
+      ])
+
+      if (favoritesRes.ok) {
+        const favData = await favoritesRes.json()
+        setFavorites(favData.favorites || [])
+      }
+
+      if (collectionsRes.ok) {
+        const collData = await collectionsRes.json()
+        setCollections(collData.collections || [])
+      }
+
+      setShowLoginModal(false)
+      setLoginCode('')
+      showToast(`Welcome, ${userData.name || userData.github_username || 'SkillHub user'}!`, 'success')
+    } catch (error) {
+      console.error('Login failed:', error)
+      showToast('Login failed. Please try again.', 'error')
+    } finally {
+      setLoggingIn(false)
+    }
+  }
+
+  const renderLoginGate = () => (
+    <div className="p-8 flex flex-col items-center justify-center min-h-[calc(100vh-6rem)]">
+      <div className="max-w-xl text-center space-y-5">
+        <div className="inline-flex items-center gap-3 px-4 py-2 border-2 border-foreground bg-secondary uppercase tracking-wider text-sm font-semibold">
+          <Store size={18} />
+          Marketplace
         </div>
-
-        <h1 className="text-4xl font-bold text-foreground mb-4 tracking-tight">
-          MARKETPLACE
-        </h1>
-
-        <p className="text-xl text-muted-foreground mb-8 uppercase tracking-wider">
-          Coming Soon
+        <h1 className="text-4xl font-bold tracking-tight text-foreground">Sign in to explore user-hosted skills</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Access the new marketplace of community and private skills. Filter, preview, and install directly to your tools once authenticated.
         </p>
-
-        <div className="border-2 border-border-light p-6">
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            The SkillHub Marketplace will allow you to discover, purchase, and sell premium AI coding skills.
-            Stay tuned for updates!
-          </p>
+        <div className="flex items-center justify-center gap-3 flex-wrap">
+          <button
+            onClick={startLogin}
+            className="btn btn-primary"
+          >
+            Start sign-in
+          </button>
+          <button
+            onClick={() => setShowLoginModal(true)}
+            className="btn btn-secondary"
+          >
+            I already have a code
+          </button>
         </div>
       </div>
+    </div>
+  )
+
+  if (!isAuthenticated || !accessToken) {
+    return (
+      <>
+        {renderLoginGate()}
+        {showLoginModal && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-background border-2 border-foreground p-6 w-full max-w-sm mx-4">
+              <h2 className="text-xl font-bold mb-2 tracking-tight">Enter login code</h2>
+              <p className="text-muted-foreground text-sm mb-4">
+                Paste the 8-digit code from the browser window.
+              </p>
+              <input
+                type="text"
+                value={loginCode}
+                onChange={(e) => setLoginCode(e.target.value)}
+                placeholder="XXXXXXXX"
+                maxLength={8}
+                className="input text-center text-2xl font-mono tracking-widest mb-4"
+              />
+              <div className="flex gap-3">
+                <button
+                  onClick={() => {
+                    setShowLoginModal(false)
+                    setLoginCode('')
+                  }}
+                  className="btn btn-secondary flex-1"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleLoginSubmit}
+                  disabled={loggingIn || !loginCode.trim()}
+                  className="btn btn-primary flex-1 disabled:opacity-50"
+                >
+                  {loggingIn ? 'Signing in...' : 'Submit'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    )
+  }
+
+  const startItemIndex = (page - 1) * pageSize + 1
+  const endItemIndex = Math.min(total, page * pageSize)
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="inline-flex items-center gap-2 px-3 py-1 border-2 border-foreground bg-secondary uppercase tracking-wider text-xs font-bold">
+            <Store size={16} />
+            Marketplace
+          </div>
+          <h1 className="text-3xl font-bold text-foreground tracking-tight mt-2">User-hosted skills</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse public skills uploaded by the community, filtered and ready for installation.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="text-right">
+            <p className="text-xl font-bold text-foreground leading-tight">{total.toLocaleString()}</p>
+            <p className="text-xs uppercase tracking-widest text-muted-foreground">Skills available</p>
+          </div>
+          <button
+            onClick={() => setRefreshKey((n) => n + 1)}
+            className="btn btn-secondary"
+          >
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="grid gap-3 lg:grid-cols-4 md:grid-cols-2">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={16} />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search marketplace..."
+            className="input pl-10"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <div className="flex-1 relative">
+            <Tag className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={16} />
+            <input
+              type="text"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+              placeholder="Filter by tag"
+              className="input pl-10"
+            />
+          </div>
+          <button
+            onClick={() => setHasCoverOnly((v) => !v)}
+            className={`px-3 border-2 flex items-center gap-2 uppercase tracking-wider text-xs font-semibold ${
+              hasCoverOnly ? 'bg-foreground text-background border-foreground' : 'border-border-light hover:border-foreground'
+            }`}
+          >
+            <Image size={14} />
+            Cover
+          </button>
+        </div>
+
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground mb-1">
+              <Filter size={12} />
+              Category
+            </div>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="input"
+            >
+              {CATEGORY_OPTIONS.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground mb-1">
+            <ArrowUpDown size={12} />
+            Sort
+          </div>
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as MarketplaceSortOption)}
+            className="input"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Results */}
+      <div className="border-2 border-border-light bg-secondary p-4 flex items-center justify-between text-xs uppercase tracking-widest text-muted-foreground">
+        <span>
+          Showing {Math.min(endItemIndex - startItemIndex + 1, skills.length)} of {total} (page {page} / {totalPages})
+        </span>
+        <span className="flex items-center gap-2">
+          <Clock size={12} />
+          Auto-refresh disabled
+        </span>
+      </div>
+
+      {error && (
+        <div className="border-2 border-red-500 text-red-500 p-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="animate-spin text-foreground" size={32} />
+        </div>
+      ) : skills.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground border-2 border-border-light">
+          No skills found with current filters.
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {skills.map((skill) => (
+            <SkillCard
+              key={skill.id}
+              skill={toSkillCardSkill(skill)}
+              onView={() => handleViewSkill(skill)}
+              onInstall={() => handleViewSkill(skill)}
+              installing={installing && viewingSkill?.id === skill.id}
+              showPreviewButton
+              customUrl={`/web/skills/${skill.slug.replace(/\//g, '-')}`}
+              meta={{
+                coverUrl: skill.coverUrl,
+                views: skill.views,
+                downloads: skill.downloads,
+                ownerName: skill.ownerName,
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {skills.length > 0 && (
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">
+            Page {page} of {totalPages}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+              className="btn btn-secondary disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages}
+              className="btn btn-primary disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Detail / Install modal */}
+      {viewingSkill && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setViewingSkill(null)}>
+          <div
+            className="bg-background border-2 border-foreground w-full max-w-5xl max-h-[90vh] overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-4 border-b-2 border-border-light">
+              <div>
+                <p className="text-xs uppercase tracking-widest text-muted-foreground">Marketplace skill</p>
+                <h2 className="text-2xl font-bold tracking-tight text-foreground">{viewingSkill.name}</h2>
+              </div>
+              <button
+                onClick={() => setViewingSkill(null)}
+                className="p-2 text-muted-foreground hover:text-foreground hover:bg-secondary"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="grid gap-6 p-6 md:grid-cols-5 overflow-y-auto max-h-[80vh]">
+              <div className="space-y-4 md:col-span-2">
+                <div className="border-2 border-border-light p-3 bg-secondary">
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">Owner</p>
+                  <div className="flex items-center gap-2 text-sm font-semibold">
+                    <Users size={14} />
+                    {viewingSkill.ownerName || 'Unknown'}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Updated {viewingSkill.updated_at ? new Date(viewingSkill.updated_at).toLocaleDateString() : viewingSkill.updatedAt ? new Date(viewingSkill.updatedAt).toLocaleDateString() : '—'}
+                  </p>
+                </div>
+
+                <div className="border-2 border-border-light p-3 space-y-2">
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground">Install to</p>
+                  <ToolSelector showInstallTarget />
+                  <button
+                    onClick={handleInstall}
+                    disabled={loadingSkillContent || installing || !skillContent}
+                    className="btn btn-primary w-full disabled:opacity-50"
+                  >
+                    {installing ? 'Installing...' : 'Install skill'}
+                  </button>
+                  {(!skillContent || loadingSkillContent) && (
+                    <p className="text-xs text-muted-foreground">
+                      {loadingSkillContent ? 'Loading SKILL.md...' : 'Preview SKILL.md first to enable install.'}
+                    </p>
+                  )}
+                </div>
+
+                <div className="border border-border-light p-3">
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground mb-2">Tags</p>
+                  {viewingSkill.tags?.length ? (
+                    <div className="flex flex-wrap gap-1">
+                      {viewingSkill.tags.map((t) => (
+                        <span key={t} className="px-2 py-0.5 text-[11px] uppercase tracking-wider bg-secondary border border-border-light">
+                          #{t}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">No tags</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="md:col-span-3 border-2 border-border-light p-4 overflow-y-auto" data-color-mode={theme}>
+                {loadingSkillContent ? (
+                  <div className="flex items-center justify-center py-10">
+                    <Loader2 className="animate-spin text-foreground" size={28} />
+                  </div>
+                ) : skillContent ? (
+                  <div className="prose dark:prose-invert max-w-none">
+                    <MDEditor.Markdown source={skillContent} />
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted-foreground text-center py-10">
+                    No SKILL.md available to preview.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,3 +122,105 @@ export interface FileNode {
   content?: string
   metadata?: SkillFileMetadata
 }
+
+// User Hosted Skills Types
+export type SkillVisibility = 'public' | 'unlisted' | 'private'
+export type SkillStatus = 'draft' | 'published' | 'archived'
+export type FileKind = 'skill_md' | 'manifest' | 'script' | 'reference' | 'asset' | 'other'
+
+export interface UserSkill {
+  id: string
+  name: string
+  slug: string
+  description: string
+  description_zh?: string
+  category: string
+  tags: string[]
+  visibility: SkillVisibility
+  status: SkillStatus
+  currentVersion: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UserSkillFile {
+  filepath: string
+  content?: string
+  storagePath?: string
+  kind: FileKind
+  contentType: string
+  size?: number
+  hash?: string
+}
+
+export interface CreateUserSkillRequest {
+  name: string
+  description: string
+  description_zh?: string
+  category: string
+  tags?: string[]
+  visibility?: SkillVisibility
+}
+
+export interface UploadFilesRequest {
+  files: UserSkillFile[]
+  changeSummary?: string
+}
+
+export interface UploadUrlRequest {
+  filepath: string
+  contentType: string
+  size: number
+  kind: FileKind
+}
+
+export interface UploadUrlResponse {
+  bucket: string
+  storagePath: string
+  uploadUrl: string
+  expiresIn: number
+}
+
+export interface PublishSkillRequest {
+  version: number
+  changeSummary?: string
+}
+
+export interface SkillVersion {
+  version: number
+  changeSummary?: string
+  createdAt: string
+  publishedAt?: string
+}
+
+// Marketplace (user-hosted) skills
+export type MarketplaceSortOption = 'published_at_desc' | 'updated_at_desc' | 'views_desc' | 'downloads_desc' | 'name_asc'
+
+export interface MarketplaceSkill extends UserSkill {
+  ownerName?: string
+  ownerId?: string
+  ownerAvatar?: string
+  coverUrl?: string
+  hasCover?: boolean
+  downloads?: number
+  views?: number
+  published_at?: string
+  updated_at?: string
+}
+
+export interface MarketplaceQuery {
+  page?: number
+  pageSize?: number
+  q?: string
+  category?: string
+  tag?: string
+  hasCover?: boolean
+  sort?: MarketplaceSortOption
+}
+
+export interface MarketplaceResponse {
+  skills: MarketplaceSkill[]
+  page: number
+  page_size: number
+  total: number
+}


### PR DESCRIPTION
## Summary
  - Implemented Marketplace using `/api/user/skills/public` with search,
  category/tag/cover filters, pagination, and metadata.
  - Reused `SkillCard` with cover placeholder + floating Preview button; shows
  owner/views/installs for user-hosted skills.
  - Preview + install flow: clicking card/Preview loads SKILL.md, pick tools and
  install (project/global); browser dev auto-falls back to the prod API to avoid
  localhost CORS.
  - Fixed user skill external link format to `/web/skills/<slug>` (slashes ->
  hyphens).

  ## Testing
  - `npm run build`
  - Manual: log in → open Marketplace → verify list loading, search/category/tag/
  cover toggles, pagination, Preview modal, install (project/global), card links
  pointing to `/web/skills/...`, no CORS errors.

  Release Notes (v0.2.1)

  - Marketplace lands: browse/search user-hosted skills, preview SKILL.md,
    install directly; supports category/tag/cover filters, pagination, and
    metadata (owner/views/installs).
  - Card reuse: cover placeholder + floating Preview button; external links now
    use /web/skills/<slug>.
  - Dev experience: in browser mode, if localhost API is cross-origin, it falls
    back to prod API to avoid CORS.